### PR TITLE
Improvements to actions, annotations and java.util.HashMap

### DIFF
--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -32,10 +32,15 @@ annotation Throws (
 // generator-specific aspects
 
 
+annotation Deprecated ();
+
 annotation NoReturn ();
 
+annotation StopsControlFlow ();
+
 annotation TypeMapping (
-    fullClassName: string;
+    fullClassName: string = null;
+    builtin: bool = false;
 );
 
 annotation From (
@@ -45,6 +50,6 @@ annotation From (
 annotation WrapperMeta (
     src: string;
     dst: string;
-    matchInterfaces: bool = false;
+    forceMatchInterfaces: bool = false;
 );
 

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -1,0 +1,42 @@
+libsl "1.1.0";
+
+
+// language-specific aspects
+
+
+annotation Private ();
+
+annotation PackagePrivate ();
+
+annotation Public ();
+
+annotation Extends (
+    fullClassName: string;
+);
+
+annotation Implements (
+    fullInterfaceNames: array<string>;
+);
+
+annotation Transient ();
+
+annotation Throws (
+    exceptionTypes: array<string> = [];
+);
+
+
+// generator-specific aspects
+
+
+annotation NoReturn ();
+
+annotation TypeMapping (
+    fullClassName: string
+);
+
+annotation WrapperMeta (
+    src: string;
+    dst: string;
+    matchInterfaces: bool = false;
+);
+

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -32,3 +32,7 @@ annotation WrapperMeta (
     forceMatchInterfaces: bool = false;
 );
 
+// Stores a result of function computation as a private field inside of a generated class.
+// Something like: `private Set fun_keySet_cached = null;`
+annotation CacheOnce ();
+

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -3,9 +3,18 @@ libsl "1.1.0";
 
 /// generator-specific aspects
 
+// Stores the result of a function computation as a private field inside of the generated class.
+// Something like: `private Set fun_keySet_cached = null;`
+annotation CacheOnce ();
+
 // The marked feature is no longer needed or required.
 annotation Deprecated (
     hint: string = "";
+);
+
+// Specifies expected parent automaton and a class-container.
+annotation From (
+    parentAutomatonName: string;
 );
 
 // The merked method does not return to normal execution.
@@ -20,19 +29,9 @@ annotation TypeMapping (
     builtin: bool = false;
 );
 
-// Specifies expected parent automaton and a class-container.
-annotation From (
-    parentAutomatonName: string;
-);
-
 // General meta-data for a wrapper class generated from this automaton.
 annotation WrapperMeta (
     src: string;
     dst: string;
     forceMatchInterfaces: bool = false;
 );
-
-// Stores a result of function computation as a private field inside of a generated class.
-// Something like: `private Set fun_keySet_cached = null;`
-annotation CacheOnce ();
-

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -38,7 +38,7 @@ annotation TypeMapping (
     fullClassName: string;
 );
 
-annotation EmbedInto (
+annotation From (
     parentAutomatonName: string;
 );
 

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -35,3 +35,6 @@ annotation WrapperMeta (
     dst: string;
     forceMatchInterfaces: bool = false;
 );
+
+// Forces the body of a specified subroutine to be copy-pasted at the callsite.
+annotation AutoInline ();

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -4,6 +4,12 @@ libsl "1.1.0";
 // language-specific aspects
 
 
+annotation Static ();
+
+annotation Final ();
+
+annotation Transient ();
+
 annotation Private ();
 
 annotation PackagePrivate ();
@@ -18,8 +24,6 @@ annotation Implements (
     fullInterfaceNames: array<string>;
 );
 
-annotation Transient ();
-
 annotation Throws (
     exceptionTypes: array<string> = [];
 );
@@ -31,7 +35,11 @@ annotation Throws (
 annotation NoReturn ();
 
 annotation TypeMapping (
-    fullClassName: string
+    fullClassName: string;
+);
+
+annotation EmbedInto (
+    parentAutomatonName: string;
 );
 
 annotation WrapperMeta (

--- a/spec/generator-annotations.lsl
+++ b/spec/generator-annotations.lsl
@@ -1,52 +1,31 @@
 libsl "1.1.0";
 
 
-// language-specific aspects
+/// generator-specific aspects
 
-
-annotation Static ();
-
-annotation Final ();
-
-annotation Transient ();
-
-annotation Private ();
-
-annotation PackagePrivate ();
-
-annotation Public ();
-
-annotation Extends (
-    fullClassName: string;
+// The marked feature is no longer needed or required.
+annotation Deprecated (
+    hint: string = "";
 );
 
-annotation Implements (
-    fullInterfaceNames: array<string>;
-);
-
-annotation Throws (
-    exceptionTypes: array<string> = [];
-);
-
-
-// generator-specific aspects
-
-
-annotation Deprecated ();
-
+// The merked method does not return to normal execution.
 annotation NoReturn ();
 
+// The marked action stops execution of current control flow by throwing exception or other means.
 annotation StopsControlFlow ();
 
+// Associates the type on the LEFT side of typealias with the specified type.
 annotation TypeMapping (
     fullClassName: string = null;
     builtin: bool = false;
 );
 
+// Specifies expected parent automaton and a class-container.
 annotation From (
     parentAutomatonName: string;
 );
 
+// General meta-data for a wrapper class generated from this automaton.
 annotation WrapperMeta (
     src: string;
     dst: string;

--- a/spec/java-common.lsl
+++ b/spec/java-common.lsl
@@ -50,7 +50,7 @@ define action CALL(
 define action OBJECT_EQUALS(
         a: Object,
         b: Object
-    ): string;
+    ): boolean;
 
 define action OBJECT_TO_STRING(
         thing: Object
@@ -66,29 +66,33 @@ define action OBJECT_HASH_CODE(
 
 
 
-annotation Static ();
+annotation static ();
 
-annotation Final ();
+annotation final ();
 
-annotation Transient ();
+annotation transient ();
 
-annotation Private ();
+annotation private ();
 
-annotation PackagePrivate ();
+annotation packageprivate ();
 
-annotation Public ();
+annotation public ();
 
-annotation Extends (
+annotation extends (
     fullClassName: string;
 );
 
-annotation Implements (
+annotation implements (
     fullInterfaceNames: array<string>;
 );
 
-annotation Throws (
+annotation throws (
     exceptionTypes: array<string> = [];
 );
+
+annotation synchronized ();
+
+annotation varargs ();
 
 
 

--- a/spec/java-common.lsl
+++ b/spec/java-common.lsl
@@ -1,6 +1,11 @@
-libsl '1.1.0';
+libsl "1.1.0";
 
-library 'std:common' language 'Java' version '11' url '-';
+library "std" language "Java" version "11" url "-";
+
+
+// === IMPORTS ===
+
+import "generator-annotations.lsl";
 
 
 // === TYPES ===
@@ -12,7 +17,7 @@ typealias long    = int64;
 typealias float   = float32;
 typealias double  = float64;
 
-@Alias('java.lang.Object')
+@TypeMapping("java.lang.Object")
 typealias Object = *void;
 
 

--- a/spec/java-common.lsl
+++ b/spec/java-common.lsl
@@ -47,6 +47,7 @@ define action CALL(
 
 // "ad-hoc" solutions
 
+// the same as something like: return a == b || (a != null && a.equals(b))
 define action OBJECT_EQUALS(
         a: Object,
         b: Object

--- a/spec/java-common.lsl
+++ b/spec/java-common.lsl
@@ -2,33 +2,13 @@ libsl "1.1.0";
 
 library "std" language "Java" version "11" url "-";
 
-
-// === IMPORTS ===
-
+// DO NOT REMOVE!
 import "generator-annotations.lsl";
 
 
-// === TYPES ===
-
-
-@TypeMapping(builtin=true) typealias boolean = bool;
-@TypeMapping(builtin=true) typealias int     = int32;
-@TypeMapping(builtin=true) typealias long    = int64;
-@TypeMapping(builtin=true) typealias float   = float32;
-@TypeMapping(builtin=true) typealias double  = float64;
-@TypeMapping(builtin=true) typealias Object  = *void;
-
-
-// === CONSTANTS ===
-
-
-//val null: Object = 0;
-
-//val false: boolean = 0;
-//val true: boolean = 1;
-
 
 // === ACTIONS ===
+
 
 
 // specification development -related actions
@@ -79,3 +59,58 @@ define action OBJECT_TO_STRING(
 define action OBJECT_HASH_CODE(
         thing: Object
     ): int;
+
+
+
+// === ANNOTATIONS ===
+
+
+
+annotation Static ();
+
+annotation Final ();
+
+annotation Transient ();
+
+annotation Private ();
+
+annotation PackagePrivate ();
+
+annotation Public ();
+
+annotation Extends (
+    fullClassName: string;
+);
+
+annotation Implements (
+    fullInterfaceNames: array<string>;
+);
+
+annotation Throws (
+    exceptionTypes: array<string> = [];
+);
+
+
+
+// === CONSTANTS ===
+
+
+
+//val null: Object = 0;
+
+//val false: boolean = 0;
+//val true: boolean = 1;
+
+
+
+// === TYPES ===
+
+
+
+@TypeMapping(builtin=true) typealias boolean = bool;
+@TypeMapping(builtin=true) typealias int     = int32;
+@TypeMapping(builtin=true) typealias long    = int64;
+@TypeMapping(builtin=true) typealias float   = float32;
+@TypeMapping(builtin=true) typealias double  = float64;
+@TypeMapping(builtin=true) typealias Object  = *void;
+

--- a/spec/java-common.lsl
+++ b/spec/java-common.lsl
@@ -11,43 +11,27 @@ import "generator-annotations.lsl";
 // === TYPES ===
 
 
-typealias boolean = bool;
-typealias int     = int32;
-typealias long    = int64;
-typealias float   = float32;
-typealias double  = float64;
-
-@TypeMapping("java.lang.Object")
-typealias Object = *void;
+@TypeMapping(builtin=true) typealias boolean = bool;
+@TypeMapping(builtin=true) typealias int     = int32;
+@TypeMapping(builtin=true) typealias long    = int64;
+@TypeMapping(builtin=true) typealias float   = float32;
+@TypeMapping(builtin=true) typealias double  = float64;
+@TypeMapping(builtin=true) typealias Object  = *void;
 
 
 // === CONSTANTS ===
 
 
-val null: Object = 0;
+//val null: Object = 0;
 
-val false: boolean = 0;
-val true: boolean = 1;
+//val false: boolean = 0;
+//val true: boolean = 1;
 
 
 // === ACTIONS ===
 
 
-@NoReturn
-define action THROW_NEW(
-        exceptionType: string,
-        params: any[]
-    ): void;
-
-@NoReturn
-define action THROW_VALUE(
-        value: any
-    ): void;
-
-@NoReturn
-define action ERROR(
-        message: string
-    ): void;
+// specification development -related actions
 
 @NoReturn
 define action TODO(): void;
@@ -55,20 +39,43 @@ define action TODO(): void;
 @NoReturn
 define action NOT_IMPLEMENTED(): void;
 
+@NoReturn
+define action ERROR(message: string): void;
+
+
+// language-specific features
+
+@StopsControlFlow
+define action THROW_NEW(
+        exceptionType: string,
+        params: array<any>
+    ): void;
+
+@StopsControlFlow
+define action THROW_VALUE(
+        value: any
+    ): void;
+
+
+// work-arounds
+
 define action CALL(
         callable: Object,
-        params: any[]
+        params: array<any>
     ): Object;
 
+
+// "ad-hoc" solutions
+
 define action OBJECT_EQUALS(
-        a: any,
-        b: any
+        a: Object,
+        b: Object
     ): string;
 
 define action OBJECT_TO_STRING(
-        thing: any
+        thing: Object
     ): string;
 
 define action OBJECT_HASH_CODE(
-        thing: any
+        thing: Object
     ): int;

--- a/spec/java-common.lsl
+++ b/spec/java-common.lsl
@@ -59,3 +59,16 @@ define action CALL(
         callable: Object,
         params: any[]
     ): Object;
+
+define action OBJECT_EQUALS(
+        a: any,
+        b: any
+    ): string;
+
+define action OBJECT_TO_STRING(
+        thing: any
+    ): string;
+
+define action OBJECT_HASH_CODE(
+        thing: any
+    ): int;

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -220,9 +220,10 @@ automaton HashMap: int
 
         if (initialCapacity < 0)
         {
+            val initCapStr = action OBJECT_TO_STRING(initialCapacity);
             action THROW_NEW(
                 "java.lang.IllegalArgumentException",
-                ["Illegal initial capacity: " + initialCapacity]);
+                ["Illegal initial capacity: " + initCapStr]);
         }
 
         self._initLists();
@@ -248,16 +249,18 @@ automaton HashMap: int
 
         if (initialCapacity < 0)
         {
+            val initCapStr = action OBJECT_TO_STRING(initialCapacity);
             action THROW_NEW(
                 "java.lang.IllegalArgumentException",
-                ["Illegal initial capacity: " + initialCapacity]); // #problem
+                ["Illegal initial capacity: " + initCapStr]);
         }
 
         if (loadFactor <= 0 || loadFactor.isNaN)
         {
+            val loadFactorStr = action OBJECT_TO_STRING(loadFactor);
             action THROW_NEW(
                 "java.lang.IllegalArgumentException",
-                ["Illegal load factor: " + loadFactor]);
+                ["Illegal load factor: " + loadFactorStr]);
         }
 
         self._initLists();
@@ -538,8 +541,8 @@ automaton HashMap: int
         if (idx >= 0)
         {
             val value = action LIST_GET(values, idx);
-            // #problem
-            if (value == oldValue || (value != null && Objects.equals(value, oldValue)))
+            val providedValueEqToOld = action OBJECT_EQUALS(value, oldValue);
+            if (providedValueEqToOld)
             {
                 action LIST_SET(values, idx, newValue);
 

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -78,7 +78,7 @@ automaton HashMap: int
         ensures self.keys != null;
         ensures self.values != null;
 
-        keys = new list();
+        keys = new list(); // #problem: can we use LIST_RESIZE to also allocate this object?
         values = new list();
     }
 
@@ -103,7 +103,7 @@ automaton HashMap: int
 
     proc _getMappingOrDefault (key: Object, defaultValue: Object): Object
     {
-        val idx = action LIST_FIND(keys, key);
+        val idx = action LIST_FIND(keys, key, 0, length, +1);
         if (idx >= 0)
         {
             result = action LIST_GET(values, idx);
@@ -121,7 +121,7 @@ automaton HashMap: int
         assigns self.values;
         ensures self.length' >= self.length;
 
-        val idx = action LIST_FIND(keys, key);
+        val idx = action LIST_FIND(keys, key, 0, length, +1);
         if (idx >= 0)
         {
             result = action LIST_GET(values, idx);
@@ -169,7 +169,7 @@ automaton HashMap: int
         // side effects should be inferred from calls to other subroutines
         ensures self.length' <= self.length;
 
-        val idx = action LIST_FIND(keys, key);
+        val idx = action LIST_FIND(keys, key, 0, length, +1);
         if (idx >= 0)
         {
             result = self._removeMapping(idx);
@@ -296,7 +296,7 @@ automaton HashMap: int
         }
         else
         {
-            val idx = action LIST_FIND(keys, key);
+            val idx = action LIST_FIND(keys, key, 0, length, +1);
             result = idx >= 0;
         }
     }
@@ -310,7 +310,7 @@ automaton HashMap: int
         }
         else
         {
-            val idx = action LIST_FIND(values, value);
+            val idx = action LIST_FIND(values, value, 0, length, +1);
             result = idx >= 0;
         }
     }
@@ -454,7 +454,7 @@ automaton HashMap: int
 
         result = false;
 
-        val idx = action LIST_FIND(keys, key);
+        val idx = action LIST_FIND(keys, key, 0, length, +1);
         if (idx >= 0)
         {
             val oldValue = action LIST_GET(values, idx);
@@ -462,7 +462,7 @@ automaton HashMap: int
             val isEqualValues = Objects.equals(value, oldValue);  // #problem
             if (isEqualValues)
             {
-                self._removeMapping(m, key);
+                self._removeMapping(idx);
 
                 result = true;
             }
@@ -490,7 +490,7 @@ automaton HashMap: int
 
         result = false;
 
-        val idx = action LIST_FIND(keys, key);
+        val idx = action LIST_FIND(keys, key, 0, length, +1);
         if (idx >= 0)
         {
             val value = action LIST_GET(values, idx);
@@ -515,8 +515,8 @@ automaton HashMap: int
 
     fun clone (): Object
     {
-        val cKeys   = action LIST_DUP(keys);
-        val cValues = action LIST_DUP(values);
+        val cKeys   = action LIST_COPY(keys, 0, length);
+        val cValues = action LIST_COPY(values, 0, length);
 
         result = new HashMap(
             state=self.state, keys=cKeys, values=cValues, length=self.length);
@@ -684,7 +684,7 @@ automaton HashMap_Values: int
         }
         else
         {
-            result = action LIST_FIND(self.parent.values, value);
+            result = action LIST_FIND(self.parent.values, value, 0, self.parent.length, +1);
         }
     }
 
@@ -780,7 +780,7 @@ automaton HashMap_KeySet: int
         }
         else
         {
-            result = action LIST_FIND(self.parent.keys, key);
+            result = action LIST_FIND(self.parent.keys, key, 0, self.parent.length, +1);
         }
     }
 

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -22,7 +22,7 @@ typealias ObjectInputStream = Object;  // #problem
 @WrapperMeta(
     src="java.util.HashMap",
     dst="ru.spbpu.libsl.overrides.collections.HashMap",
-    matchInterfaces=true,
+    forceMatchInterfaces=true,
 )
 automaton HashMap: int
 (

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -68,7 +68,7 @@ automaton HashMap: int
     proc _updateModifications(): void
     {
         assigns self.modCounter;
-        ensures self.modCounter" > self.modCounter;
+        ensures self.modCounter' > self.modCounter;
 
         self.modCounter += 1;
     }
@@ -101,7 +101,7 @@ automaton HashMap: int
     {
         assigns self.keys;
         assigns self.values;
-        ensures self.length" >= self.length;
+        ensures self.length' >= self.length;
 
         val idx = action LIST_FIND(keys, key);
         if (idx >= 0)
@@ -134,7 +134,7 @@ automaton HashMap: int
         requires index >= 0 && index < self.length;
         assigns self.keys;
         assigns self.values;
-        ensures self.length" <= self.length;
+        ensures self.length' <= self.length;
 
         result = action LIST_GET(values, index);
         

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -11,6 +11,10 @@ import "java/util/interfaces.lsl"
 import "java/util/function/interfaces.lsl"
 
 
+@TypeMapping("java.util.ObjectInputStream")
+typealias ObjectInputStream = Object;  // #problem
+
+
 // automata
 
 @Public
@@ -576,19 +580,25 @@ automaton HashMap: int
 
     // problematic methods
 
-    fun toString (): string
-    {
-        // result = action OBJECT_TO_STRING(self);
-        // #problem
-        action NOT_IMPLEMENTED();
-    }
+//    fun toString (): string
+//    {
+//        // result = action OBJECT_TO_STRING(self);
+//        // #problem
+//        action NOT_IMPLEMENTED();
+//    }
 
-    fun hashCode (): int
-    {
-        // result = action OBJECT_HASH_CODE(self);
-        // #problem
-        action NOT_IMPLEMENTED();
-    }
+//    fun hashCode (): int
+//    {
+//        // result = action OBJECT_HASH_CODE(self);
+//        // #problem
+//        action NOT_IMPLEMENTED();
+//    }
+
+//    fun equals (other: Object): boolean
+//    {
+//        // #problem
+//        action NOT_IMPLEMENTED();
+//    }
 
     fun forEach (consumer: BiConsumer): void
     {
@@ -614,36 +624,32 @@ automaton HashMap: int
         action NOT_IMPLEMENTED();
     }
 
-    fun equals (other: Object): boolean
-    {
-        // #problem
-        action NOT_IMPLEMENTED();
-    }
-
     @Private
     @Throws(["IOException", "ClassNotFoundException"])
     fun readObject(s: ObjectInputStream): void
     {
         requires s != null;
 
-        val size = s.readInt();
+        action NOT_IMPLEMENTED();
 
-        // #problem
-        val buff = new int[size];
-        // #problem
-        s.readFully(buff);
+//        val size = s.readInt();
 
-        // #problem
-        action FROM_BYTES(self, bytes);
+//        // #problem
+//        val buff = new int[size];
+//        // #problem
+//        s.readFully(buff);
+
+//        // #problem
+//        action FROM_BYTES(self, bytes);
     }
 }
 
 
 
 
+@From("HashMap")
 @PackagePrivate
 @Extends("java.util.AbstractCollection")
-@EmbedInto("HashMap")
 automaton HashMap_Values: int
 {
     initstate Initialized;
@@ -654,7 +660,7 @@ automaton HashMap_Values: int
         contains,
 
         iterator,
-        spliterator,
+//        spliterator,
 
         // write operations
         clear,
@@ -690,10 +696,11 @@ automaton HashMap_Values: int
     }
 
 
-    fun spliterator(): Spliterator
-    {
-        result = new HashMap_ValueSpliterator(state=Initialized, parent=self.parent);
-    }
+// #todo
+//    fun spliterator(): Spliterator
+//    {
+//        result = new HashMap_ValueSpliterator(state=Initialized, parent=self.parent);
+//    }
 
 
     fun clear(): void
@@ -714,9 +721,9 @@ automaton HashMap_Values: int
 
 
 
+@From("HashMap")
 @PackagePrivate
 @Extends("java.util.AbstractSet")
-@EmbedInto("HashMap")
 automaton HashMap_KeySet: int
 {
     initstate Initialized;
@@ -727,6 +734,7 @@ automaton HashMap_KeySet: int
         contains,
 
         iterator,
+//        spliterator,
 
         // write operations
         clear,
@@ -757,6 +765,13 @@ automaton HashMap_KeySet: int
     }
 
 
+// #todo
+//    fun spliterator (): Spliterator
+//    {
+//        result = new HashMap_KeySpliterator(state=Initialized, parent=self.parent);
+//    }
+
+
     fun contains (key: Object): boolean
     {
         if (self.parent.length == 0)
@@ -782,9 +797,9 @@ automaton HashMap_KeySet: int
 
 
 
+@From("HashMap")
 @PackagePrivate
 @Implements(["java.util.Iterator"])
-@EmbedInto("HashMap")
 automaton HashMap_KeyIterator: int
 (
     var index: int = 0;
@@ -849,9 +864,9 @@ automaton HashMap_KeyIterator: int
 
 
 
+@From("HashMap")
 @PackagePrivate
 @Implements(["java.util.Iterator"])
-@EmbedInto("HashMap")
 automaton HashMap_ValueIterator: int
 (
     var index: int = 0;
@@ -916,6 +931,190 @@ automaton HashMap_ValueIterator: int
 
 
 
+@From("HashMap")
+@PackagePrivate
+@Implements(["java.util.Map.Entry"])
+automaton HashMap_Entry: int
+(
+    var index: int;
+)
+{
+    initstate Initialized;
+
+    shift Initialized -> self by [
+        // read operations
+
+        getKey,
+        getValue,
+
+        equals,
+        toString,
+        hashCode,
+
+        // write operations
+
+        setValue,
+    ];
+
+
+    // methods
+
+    fun getKey (): Object
+    {
+        // TODO: key caching
+
+        // we do not have references to arbitrary types, so 'action' it is
+        result = action LIST_GET(self.parent.keys, index);
+    }
+
+
+    fun getValue (): Object
+    {
+        result = action LIST_GET(self.parent.values, index);
+    }
+
+
+    fun setValue (newValue: Object): Object
+    {
+        result = action LIST_GET(self.parent.values, index);
+
+        action LIST_SET(self.parent.values, index, newValue);
+    }
+
+
+    fun equals (other: Object): Object
+    {
+        if (other == self)
+        {
+            result = true;
+        }
+        else
+        {
+            // #problem
+            // instanceof
+
+            // #problem
+            // val key = action CALL_INTERFACE(other, "getKey():java.lang.Object", []);
+
+            action NOT_IMPLEMENTED();
+        }
+    }
+
+
+    fun toString (): string
+    {
+        val key   = action LIST_GET(self.parent.keys, index);
+        val value = action LIST_GET(self.parent.values, index);
+
+        val sKey   = action OBJECT_TO_STRING(key);
+        val sValue = action OBJECT_TO_STRING(value);
+
+        result = sKey + "=" + sValue;
+    }
+
+
+    fun hashCode (): int
+    {
+        val key   = action LIST_GET(self.parent.keys, index);
+        val value = action LIST_GET(self.parent.values, index);
+
+        val hKey   = action OBJECT_HASH_CODE(key);
+        val hValue = action OBJECT_HASH_CODE(value);
+
+        result = hKey ^ hValue;
+    }
+
+}
+
+
+
+
+@From("HashMap")
+@PackagePrivate
+@Extends("java.util.AbstractSet")
+automaton HashMap_EntrySet: int
+{
+    initstate Initialized;
+
+    shift Initialized -> self by [
+        // read operations
+        size,
+        contains,
+
+        iterator,
+        spliterator,
+
+        // write operations
+        clear,
+        remove,
+    ];
+
+
+    // methods
+
+    fun size (): int
+    {
+        result = self.parent.length;
+    }
+
+
+    fun clear (): void
+    {
+        assigns self.parent;
+
+        result = self.parent._clearMappings();
+    }
+
+
+    fun iterator (): Iterator
+    {
+        result = new HashMap_EntryIterator(
+            state=Initialized, parent=self.parent, expectedModCount=self.parent.modCounter);
+    }
+
+
+    fun spliterator (): Spliterator
+    {
+        result = new HashMap_EntrySpliterator(state=Initialized, parent=self.parent);
+    }
+
+
+    fun contains (e: Object): boolean
+    {
+        if (self.parent.length == 0)
+        {
+            result = false;
+        }
+        else
+        {
+            // #problem
+            // instanceof
+
+            // #problem
+            // val key = action CALL_INTERFACE(other, "getKey():java.lang.Object", []);
+
+            action NOT_IMPLEMENTED();
+        }
+    }
+
+
+    fun remove (e: Object): boolean
+    {
+        assigns self.parent;
+
+        // #problem
+        // val key = action CALL_INTERFACE(e, "getKey():java.lang.Object", []);
+
+        val oldValue = self.parent._removeMapping(key);
+        result = oldValue != null;
+    }
+}
+
+
+
+
 // TODO
+// HashMap_EntryIterator
 // HashMap_ValueSpliterator
-// HashMap_EntrySet
+// HashMap_KeySpliterator
+// HashMap_EntrySpliterator

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -751,7 +751,7 @@ automaton HashMap_KeySet: int
 
 
 @PackagePrivate
-@Implements("java.util.Iterator")
+@Implements(["java.util.Iterator"])
 automaton HashMap_KeyIterator: int
 (
     var index: int = 0;

--- a/spec/java/util/HashMap.lsl
+++ b/spec/java/util/HashMap.lsl
@@ -170,8 +170,8 @@ automaton HashMap: int
         assigns self.values;
         assigns self.length;
         assigns self.modCounter;
-        ensures self.length = 0;
-        ensures self.modCounter = 0;
+        ensures self.length == 0;
+        ensures self.modCounter == 0;
 
         length = 0;
         modCounter = 0;
@@ -187,8 +187,8 @@ automaton HashMap: int
         assigns self.values;
         assigns self.length;
         assigns self.modCounter;
-        ensures self.length = 0;
-        ensures self.modCounter = 0;
+        ensures self.length == 0;
+        ensures self.modCounter == 0;
 
         length = 0;
         modCounter = 0;
@@ -206,8 +206,8 @@ automaton HashMap: int
         assigns self.values;
         assigns self.length;
         assigns self.modCounter;
-        ensures self.length = 0;
-        ensures self.modCounter = 0;
+        ensures self.length == 0;
+        ensures self.modCounter == 0;
 
         length = 0;
         modCounter = 0;
@@ -223,7 +223,7 @@ automaton HashMap: int
         assigns self.values;
         assigns self.length;
         assigns self.modCounter;
-        ensures self.modCounter = 0;
+        ensures self.modCounter == 0;
 
         modCounter = 0;
         

--- a/spec/java/util/function/interfaces.lsl
+++ b/spec/java/util/function/interfaces.lsl
@@ -1,0 +1,16 @@
+libsl "1.1.0";
+
+library "std:collections" language "Java" version "11" url "-";
+
+import "java-common.lsl";
+
+
+@Alias("java.util.function.Function")
+typealias Function = Object;    // #problem
+
+@Alias("java.util.function.BiFunction")
+typealias BiFunction = Object;    // #problem
+
+@Alias("java.util.function.BiConsumer")
+typealias BiConsumer = Object;    // #problem
+

--- a/spec/java/util/function/interfaces.lsl
+++ b/spec/java/util/function/interfaces.lsl
@@ -5,12 +5,12 @@ library "std:collections" language "Java" version "11" url "-";
 import "java-common.lsl";
 
 
-@Alias("java.util.function.Function")
+@TypeMapping("java.util.function.Function")
 typealias Function = Object;    // #problem
 
-@Alias("java.util.function.BiFunction")
+@TypeMapping("java.util.function.BiFunction")
 typealias BiFunction = Object;    // #problem
 
-@Alias("java.util.function.BiConsumer")
+@TypeMapping("java.util.function.BiConsumer")
 typealias BiConsumer = Object;    // #problem
 

--- a/spec/java/util/function/interfaces.lsl
+++ b/spec/java/util/function/interfaces.lsl
@@ -5,12 +5,11 @@ library "std:collections" language "Java" version "11" url "-";
 import "java-common.lsl";
 
 
-@TypeMapping("java.util.function.Function")
-typealias Function = Object;    // #problem
+@TypeMapping("java.util.function.BiConsumer")
+typealias BiConsumer = Object;    // #problem
 
 @TypeMapping("java.util.function.BiFunction")
 typealias BiFunction = Object;    // #problem
 
-@TypeMapping("java.util.function.BiConsumer")
-typealias BiConsumer = Object;    // #problem
-
+@TypeMapping("java.util.function.Function")
+typealias Function = Object;    // #problem

--- a/spec/java/util/interfaces.lsl
+++ b/spec/java/util/interfaces.lsl
@@ -4,11 +4,11 @@ library "std:collections" language "Java" version "11" url "-";
 
 import "java-common.lsl";
 
-@Alias("java.util.Collection")
+@TypeMapping("java.util.Collection")
 typealias Map = Object;    // #problem
 
-@Alias("java.util.Set")
+@TypeMapping("java.util.Set")
 typealias Set = Object;    // #problem
 
-@Alias("java.util.Map")
+@TypeMapping("java.util.Map")
 typealias Map = Object;    // #problem

--- a/spec/java/util/interfaces.lsl
+++ b/spec/java/util/interfaces.lsl
@@ -5,10 +5,10 @@ library "std:collections" language "Java" version "11" url "-";
 import "java-common.lsl";
 
 @TypeMapping("java.util.Collection")
+typealias Collection = Object;    // #problem
+
+@TypeMapping("java.util.Map")
 typealias Map = Object;    // #problem
 
 @TypeMapping("java.util.Set")
 typealias Set = Object;    // #problem
-
-@TypeMapping("java.util.Map")
-typealias Map = Object;    // #problem

--- a/spec/java/util/interfaces.lsl
+++ b/spec/java/util/interfaces.lsl
@@ -1,0 +1,14 @@
+libsl "1.1.0";
+
+library "std:collections" language "Java" version "11" url "-";
+
+import "java-common.lsl";
+
+@Alias("java.util.Collection")
+typealias Map = Object;    // #problem
+
+@Alias("java.util.Set")
+typealias Set = Object;    // #problem
+
+@Alias("java.util.Map")
+typealias Map = Object;    // #problem

--- a/spec/list-actions.lsl
+++ b/spec/list-actions.lsl
@@ -1,9 +1,21 @@
 libsl '1.1.0';
 
 
+// === READ operations ===
+
+
+define action LIST_COPY(
+        aList: list<any>,
+        from: int,
+        to: int
+    ): list<any>;
+
 define action LIST_FIND(
         aList: list<any>,
-        value: any
+        value: any,
+        from: int,
+        to: int,
+        direction: int
     ): int;
 
 define action LIST_GET(
@@ -11,10 +23,23 @@ define action LIST_GET(
         index: int
     ): any;
 
+define action LIST_SIZE(
+        aList: list<any>
+    ): int;
+
+
+// === UPDATE operations ===
+
+
 define action LIST_INSERT_AT(
         aList: list<any>,
         index: int,
         value: any
+    ): void;
+
+define action LIST_RESIZE(
+        aList: list<any>,
+        newSize: int
     ): void;
 
 define action LIST_SET(
@@ -23,19 +48,10 @@ define action LIST_SET(
         value: any
     ): void;
 
-define action LIST_SIZE(
-        aList: list<any>
-    ): int;
 
-define action LIST_RESIZE(
-        aList: list<any>,
-        newSize: int
-    ): void;
+// === DELETE operations
 
-define action LIST_DUP(
-        aList: list<any>
-    ): list<any>;
-    
+
 define action LIST_REMOVE(
         aList: list<any>,
         index: int,


### PR DESCRIPTION
Key changes:
- Improved type mappings.
- Improved annotations.
- Improved list actions (grouping + functionality enhancements).
- Added separate generator-specific annotations.
- Added unified interface descriptions **[draft]**.
- Added a few missing pieces into spec for `java.util.HashMap`.
- Added some *documentation* in the form of comments for annotations and actions.
- Fixed syntax incompatibilities in spec for `java.util.HashMap`.

**Note:** the specification is still missing `spliterator`-s for `key`-s, `value`-s and `entry`-es. If we decide to actually use the suggested `map<key, value>` internal type, then there will be a lot of changes.