### PR TITLE
Improvements to interface declarations

### DIFF
--- a/spec/actions.array.lsl
+++ b/spec/actions.array.lsl
@@ -10,13 +10,13 @@ library any
 // === LIFE-TIME management ===
 
 
-define action ARRAY_NEW(
+define action ARRAY_NEW (
         typeName: string, // literal!
         size: int32
     ): array<any>;
 
 // unused
-define action ARRAY_FREE(
+define action ARRAY_FREE (
         arr: array<any>
     ): void;
 
@@ -24,12 +24,12 @@ define action ARRAY_FREE(
 // === READ operations ===
 
 
-define action ARRAY_GET(
+define action ARRAY_GET (
         arr: array<any>,
         itemIndex: int32
     ): any;
 
-define action ARRAY_SIZE(
+define action ARRAY_SIZE (
         arr: array<any>
     ): int32;
 
@@ -38,12 +38,12 @@ define action ARRAY_SIZE(
 
 
 // #question: do we actually need this?
-define action ARRAY_FILL(
+define action ARRAY_FILL (
         arr: array<any>,
         value: any
     ): void;
 
-define action ARRAY_COPY(
+define action ARRAY_COPY (
         src: array<any>,
         srcPos: int32,
         dst: array<any>,
@@ -51,7 +51,7 @@ define action ARRAY_COPY(
         count: int32
     ): void;
 
-define action ARRAY_SET(
+define action ARRAY_SET (
         arr: array<any>,
         itemIndex: int32,
         value: any

--- a/spec/actions.list.lsl
+++ b/spec/actions.list.lsl
@@ -10,11 +10,10 @@ library any
 // === LIFE-TIME management ===
 
 
-define action LIST_NEW(
-    ): list<any>;
+define action LIST_NEW (): list<any>;
 
 // unused
-define action LIST_FREE(
+define action LIST_FREE (
         aList: list<any>
     ): void;
 
@@ -22,19 +21,19 @@ define action LIST_FREE(
 // === READ operations ===
 
 
-define action LIST_FIND(
+define action LIST_FIND (
         aList: list<any>,
         value: any,
         from: int32,
         to: int32
     ): int32;
 
-define action LIST_GET(
+define action LIST_GET (
         aList: list<any>,
         itemIndex: int32
     ): any;
 
-define action LIST_SIZE(
+define action LIST_SIZE (
         aList: list<any>
     ): int32;
 
@@ -42,7 +41,7 @@ define action LIST_SIZE(
 // === UPDATE operations ===
 
 
-define action LIST_COPY(
+define action LIST_COPY (
         src: list<any>,
         dst: list<any>,
         srcPos: int32,
@@ -50,13 +49,13 @@ define action LIST_COPY(
         len: int32
     ): void;
 
-define action LIST_INSERT_AT(
+define action LIST_INSERT_AT (
         aList: list<any>,
         itemIndex: int32,
         value: any
     ): void;
 
-define action LIST_SET(
+define action LIST_SET (
         aList: list<any>,
         itemIndex: int32,
         value: any
@@ -66,7 +65,7 @@ define action LIST_SET(
 // === DELETE operations
 
 
-define action LIST_REMOVE(
+define action LIST_REMOVE (
         aList: list<any>,
         itemIndex: int32
     ): void;

--- a/spec/actions.map.lsl
+++ b/spec/actions.map.lsl
@@ -10,11 +10,10 @@ library any
 // === LIFE-TIME management ===
 
 
-define action MAP_NEW(
-    ): map<any, any>;
+define action MAP_NEW (): map<any, any>;
 
 // unused
-define action MAP_FREE(
+define action MAP_FREE (
         aMap: map<any, any>
     ): void;
 
@@ -22,17 +21,17 @@ define action MAP_FREE(
 // === READ operations ===
 
 
-define action MAP_GET(
+define action MAP_GET (
         aMap: map<any, any>,
         key: any
     ): any;
 
-define action MAP_HAS_KEY(
+define action MAP_HAS_KEY (
         aMap: map<any, any>,
         key: any
     ): bool;
 
-define action MAP_SIZE(
+define action MAP_SIZE (
         aMap: map<any, any>
     ): int32;
 
@@ -40,27 +39,27 @@ define action MAP_SIZE(
 // === UPDATE operations ===
 
 
-define action MAP_INTERSECT_WITH(
+define action MAP_INTERSECT_WITH (
         receiver: map<any, any>,
         otherSource: map<any, any>
-    ): any;
+    ): void;
 
-define action MAP_SET(
+define action MAP_SET (
         aMap: map<any, any>,
         key: any,
         value: any
-    ): any;
+    ): void;
 
-define action MAP_UNITE_WITH(
+define action MAP_UNITE_WITH (
         receiver: map<any, any>,
         otherSource: map<any, any>
-    ): any;
+    ): void;
 
 
 // === DELETE operations
 
 
-define action MAP_REMOVE(
+define action MAP_REMOVE (
         aMap: map<any, any>,
         key: any
     ): void;

--- a/spec/java.common.lsl
+++ b/spec/java.common.lsl
@@ -51,28 +51,17 @@ annotation strict ();
 
 
 
-// === CONSTANTS ===
-
-
-
-//val null: Object = 0;
-
-//val false: boolean = 0;
-//val true: boolean = 1;
-
-
-
 // === TYPES ===
 
 
-/*@TypeMapping(builtin=true)*/ typealias boolean = bool;
-/*@TypeMapping(builtin=true)*/ typealias byte    = int8;
-/*@TypeMapping(builtin=true)*/ typealias short   = int16;
-/*@TypeMapping(builtin=true)*/ typealias int     = int32;
-/*@TypeMapping(builtin=true)*/ typealias long    = int64;
-/*@TypeMapping(builtin=true)*/ typealias float   = float32;
-/*@TypeMapping(builtin=true)*/ typealias double  = float64;
-/*@TypeMapping(builtin=true)*/
+typealias boolean = bool;
+typealias byte    = int8;
+typealias short   = int16;
+typealias int     = int32;
+typealias long    = int64;
+typealias float   = float32;
+typealias double  = float64;
+
 type Object is java.lang.Object for Object {}
 
 
@@ -81,29 +70,41 @@ type Object is java.lang.Object for Object {}
 
 // language-specific features
 
+
 @StopsControlFlow
-define action THROW_NEW(
+define action THROW_NEW (
         exceptionType: string,
         params: array<any>
     ): void;
 
 @StopsControlFlow
-define action THROW_VALUE(
+define action THROW_VALUE (
         value: any
     ): void;
 
 
+
+
 // work-arounds
 
-define action CALL(
+
+define action CALL (
         callable: any,
-        params: array<any>
+        args: array<any>
     ): any;
 
 
-// "ad-hoc" solutions
+define action CALL_METHOD (
+        obj: any,           // variable!
+        methodName: string, // literal!
+        args: array<any>
+    ): any;
 
-// the same as something like: return a == b || (a != null && a.equals(b))
+
+
+// helper methods in runtime
+
+
 define action OBJECT_EQUALS(
         a: any,
         b: any

--- a/spec/java.common.lsl
+++ b/spec/java.common.lsl
@@ -102,7 +102,7 @@ define action CALL (
 
 
 define action CALL_METHOD (
-        obj: any,           // variable!
+        obj: any,
         methodName: string, // literal!
         args: array<any>
     ): any;

--- a/spec/java.common.lsl
+++ b/spec/java.common.lsl
@@ -49,6 +49,10 @@ annotation volatile ();
 
 annotation strict ();
 
+annotation FunctionalInterface (
+    callableName: string = null
+);
+
 
 
 // === TYPES ===

--- a/spec/java.common.lsl
+++ b/spec/java.common.lsl
@@ -66,7 +66,10 @@ typealias long    = int64;
 typealias float   = float32;
 typealias double  = float64;
 
-type Object is java.lang.Object for Object {}
+type Object is java.lang.Object for Object
+{
+    // WARNING: use OBJECT_HASH_CODE and OBJECT_EQUALS actions instead of calling these methods directly
+}
 
 
 // === ACTIONS ===

--- a/spec/java/io/_interfaces.lsl
+++ b/spec/java/io/_interfaces.lsl
@@ -4,7 +4,7 @@ libsl "1.1.0";
 library std
     version "11"
     language "Java"
-    url "-";
+    url "https://github.com/openjdk/jdk11/tree/master/src/java.base/share/classes/java/io";
 
 // imports
 
@@ -12,11 +12,17 @@ import java.common;
 import java/lang/_interfaces;
 
 
-// local semantic types
+// semantic types
 
-type ObjectInputStream is java.io.ObjectInputStream for Object {
+type ObjectInputStream
+    is java.io.ObjectInputStream
+    for Object
+{
 }
 
 
-type ObjectOutputStream is java.io.ObjectOutputStream for Object {
+type ObjectOutputStream
+    is java.io.ObjectOutputStream
+    for Object
+{
 }

--- a/spec/java/lang/_interfaces.lsl
+++ b/spec/java/lang/_interfaces.lsl
@@ -4,20 +4,23 @@ libsl "1.1.0";
 library std
     version "11"
     language "Java"
-    url "-";
+    url "https://github.com/openjdk/jdk11/tree/master/src/java.base/share/classes/java/lang";
+
+// imports
 
 import java.common;
+
 
 // boxed built-in types
 
 type Boolean is java.lang.Boolean for Object, bool {}
 
-type Byte is java.lang.Byte for Object, int8 {}
-type Short is java.lang.Short for Object, int16 {}
-type Integer is java.lang.Integer for Object, int32 {}
-type Long is java.lang.Long for Object, int64 {}
+type Byte    is java.lang.Byte    for Object, int8,  unsigned8  {}
+type Short   is java.lang.Short   for Object, int16, unsigned16 {}
+type Integer is java.lang.Integer for Object, int32, unsigned32 {}
+type Long    is java.lang.Long    for Object, int64, unsigned64 {}
 
-type Float is java.lang.Float for Object, float32 {}
+type Float  is java.lang.Float  for Object, float32 {}
 type Double is java.lang.Double for Object, float64 {}
 
 
@@ -29,11 +32,11 @@ type CharSequence
 
     fun charAt(index: int): char;
 
-    fun toString(): string; // #problem
+    fun toString(): string; // #problem: using forward-declared type
 }
 
 type Character is java.lang.Character for Object, char {}
-type String is java.lang.String for CharSequence, string {}
+type String    is java.lang.String    for CharSequence, string {}
 
 
 // general interfaces

--- a/spec/java/util/_interfaces.lsl
+++ b/spec/java/util/_interfaces.lsl
@@ -4,13 +4,17 @@ libsl "1.1.0";
 library std
     version "11"
     language "Java"
-    url "-";
+    url "https://github.com/openjdk/jdk11/tree/master/src/java.base/share/classes/java/util";
+
+// imports
 
 import java.common;
 import java/lang/_interfaces;
 
 
-@Parameterized(["T"]) // #problem
+// semantic types
+
+@Parameterized(["T"])
 type Comparator
     is java.util.Comparator
     for Object
@@ -19,7 +23,7 @@ type Comparator
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type Iterator
     is java.util.Iterator
     for Object
@@ -30,7 +34,7 @@ type Iterator
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type Spliterator
     is java.util.Spliterator
     for Object
@@ -38,14 +42,14 @@ type Spliterator
 }
 
 
-@Parameterized(["K", "V"]) // #problem
+@Parameterized(["K", "V"])
 type Map
     is java.util.Map
     for Object
 {
 }
 
-@Parameterized(["K", "V"]) // #problem
+@Parameterized(["K", "V"])
 type MapEntry
     is java.util.Map.Entry
     for Object
@@ -53,7 +57,7 @@ type MapEntry
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type Collection
     is java.util.Collection
     for Iterable
@@ -62,7 +66,7 @@ type Collection
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type List
     is java.util.List
     for Collection
@@ -70,7 +74,7 @@ type List
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type Set
     is java.util.Set
     for Collection
@@ -78,7 +82,7 @@ type Set
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type Queue
     is java.util.Queue
     for Collection
@@ -86,7 +90,7 @@ type Queue
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type Deque
     is java.util.Deque
     for Queue
@@ -94,7 +98,7 @@ type Deque
 }
 
 
-@Parameterized(["E"]) // #problem
+@Parameterized(["E"])
 type ListIterator
     is java.util.ListIterator
     for Iterator

--- a/spec/java/util/_interfaces.lsl
+++ b/spec/java/util/_interfaces.lsl
@@ -47,13 +47,35 @@ type Map
     is java.util.Map
     for Object
 {
+    fun size(): int;
+
+    fun isEmpty(): boolean;
+
+    fun containsKey(key: Object): boolean;
+
+    fun containsValue(value: Object): boolean;
+
+    fun get(key: Object): Object;
+
+    fun put(key: Object, value: Object): Object;
+
+    fun remove(key: Object): Object;
+
+    fun remove(key: Object, value: Object): boolean;
+
+    fun clear(): void;
 }
 
 @Parameterized(["K", "V"])
-type MapEntry
+type Map_Entry
     is java.util.Map.Entry
     for Object
 {
+    fun getKey(): Object;
+
+    fun getValue(): Object;
+
+    fun setValue(value: Object): Object;
 }
 
 
@@ -63,6 +85,45 @@ type Collection
     for Iterable
 {
     fun size(): int;
+
+    fun isEmpty(): boolean;
+
+    fun contains(o: Object): boolean;
+
+    @ParameterizedResult(["E"])
+    fun iterator(): Iterator;
+
+    fun toArray(): array<Object>;
+
+    @Parameterized(["T"])
+    @ParameterizedResult(["T"])
+    fun toArray(@Parameterized(["T"]) a: array<Object>): array<Object>;
+
+    /*
+    @Parameterized(["T"])
+    @ParameterizedResult(["T"])
+    fun toArray(@Parameterized(["T[]"]) generator: IntFunction): array<Object>;
+    */
+
+    fun add(e: Object): boolean;
+
+    fun remove(o: Object): boolean;
+
+    // #problem
+    //fun containsAll(@Parameterized(["?"]) c: Collection): boolean;
+
+    // #problem
+    //fun addAll(@Parameterized(["? extends E"]) c: Collection): boolean;
+
+    // #problem
+    //fun removeAll(@Parameterized(["?"]) c: Collection): boolean;
+
+    //fun removeIf(@Parameterized(["? super E"]) filter: Predicate): boolean;
+
+    // #problem
+    //fun retainAll(@Parameterized(["?"]) c: Collection): boolean;
+
+    fun clear(): void;
 }
 
 

--- a/spec/java/util/_interfaces.lsl
+++ b/spec/java/util/_interfaces.lsl
@@ -24,6 +24,9 @@ type Iterator
     is java.util.Iterator
     for Object
 {
+    fun hasNext(): boolean;
+
+    fun next(): Object;
 }
 
 
@@ -38,7 +41,7 @@ type Spliterator
 @Parameterized(["K", "V"]) // #problem
 type Map
     is java.util.Map
-    for Object // #question: add map here?
+    for Object
 {
 }
 
@@ -53,8 +56,9 @@ type MapEntry
 @Parameterized(["E"]) // #problem
 type Collection
     is java.util.Collection
-    for Iterable, Object
+    for Iterable
 {
+    fun size(): int;
 }
 
 

--- a/spec/java/util/function/_interfaces.lsl
+++ b/spec/java/util/function/_interfaces.lsl
@@ -4,7 +4,7 @@ libsl "1.1.0";
 library std
     version "11"
     language "Java"
-    url "-";
+    url "https://github.com/openjdk/jdk11/tree/master/src/java.base/share/classes/java/util/function";
 
 // imports
 
@@ -13,16 +13,18 @@ import java.common;
 
 // semantic types
 
-@Parameterized(["T", "U"]) // #problem
+@Parameterized(["T", "U"])
 type BiConsumer
     is java.util.function.BiConsumer
     for Object
 {
     fun accept(t: Object, u: Object): void;
+
+    // #problem: there are other methods but it will break `is-functional-interface` detection mechanism
 }
 
 
-@Parameterized(["T", "U", "R"]) // #problem
+@Parameterized(["T", "U", "R"])
 type BiFunction
     is java.util.function.BiFunction
     for Object
@@ -31,7 +33,7 @@ type BiFunction
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type BinaryOperator
     is java.util.function.BinaryOperator
     for BiFunction, Object
@@ -40,7 +42,7 @@ type BinaryOperator
 }
 
 
-@Parameterized(["T", "U"]) // #problem
+@Parameterized(["T", "U"])
 type BiPredicate
     is java.util.function.BiPredicate
     for Object
@@ -57,7 +59,7 @@ type BooleanSupplier
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type Consumer
     is java.util.function.Consumer
     for Object
@@ -82,7 +84,7 @@ type DoubleConsumer
 }
 
 
-@Parameterized(["R"]) // #problem
+@Parameterized(["R"])
 type DoubleFunction
     is java.util.function.DoubleFunction
     for Object
@@ -131,7 +133,7 @@ type DoubleUnaryOperator
 }
 
 
-@Parameterized(["T", "R"]) // #problem
+@Parameterized(["T", "R"])
 type Function
     is java.util.function.Function
     for Object
@@ -156,7 +158,7 @@ type IntConsumer
 }
 
 
-@Parameterized(["R"]) // #problem
+@Parameterized(["R"])
 type IntFunction
     is java.util.function.IntFunction
     for Object
@@ -221,7 +223,7 @@ type LongConsumer
 }
 
 
-@Parameterized(["R"]) // #problem
+@Parameterized(["R"])
 type LongFunction
     is java.util.function.LongFunction
     for Object
@@ -270,7 +272,7 @@ type LongUnaryOperator
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type ObjDoubleConsumer
     is java.util.function.ObjDoubleConsumer
     for Object
@@ -279,7 +281,7 @@ type ObjDoubleConsumer
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type ObjIntConsumer
     is java.util.function.ObjIntConsumer
     for Object
@@ -288,7 +290,7 @@ type ObjIntConsumer
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type ObjLongConsumer
     is java.util.function.ObjLongConsumer
     for Object
@@ -297,7 +299,7 @@ type ObjLongConsumer
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type Predicate
     is java.util.function.Predicate
     for Object
@@ -306,7 +308,7 @@ type Predicate
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type Supplier
     is java.util.function.Supplier
     for Object
@@ -315,7 +317,7 @@ type Supplier
 }
 
 
-@Parameterized(["T", "U"]) // #problem
+@Parameterized(["T", "U"])
 type ToDoubleBiFunction
     is java.util.function.ToDoubleBiFunction
     for Object
@@ -324,7 +326,7 @@ type ToDoubleBiFunction
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type ToDoubleFunction
     is java.util.function.ToDoubleFunction
     for Object
@@ -333,7 +335,7 @@ type ToDoubleFunction
 }
 
 
-@Parameterized(["T", "U"]) // #problem
+@Parameterized(["T", "U"])
 type ToIntBiFunction
     is java.util.function.ToIntBiFunction
     for Object
@@ -342,7 +344,7 @@ type ToIntBiFunction
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type ToIntFunction
     is java.util.function.ToIntFunction
     for Object
@@ -351,7 +353,7 @@ type ToIntFunction
 }
 
 
-@Parameterized(["T", "U"]) // #problem
+@Parameterized(["T", "U"])
 type ToLongBiFunction
     is java.util.function.ToLongBiFunction
     for Object
@@ -360,7 +362,7 @@ type ToLongBiFunction
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type ToLongFunction
     is java.util.function.ToLongFunction
     for Object
@@ -369,7 +371,7 @@ type ToLongFunction
 }
 
 
-@Parameterized(["T"]) // #problem
+@Parameterized(["T"])
 type UnaryOperator
     is java.util.function.UnaryOperator
     for Function, Object

--- a/spec/java/util/function/_interfaces.lsl
+++ b/spec/java/util/function/_interfaces.lsl
@@ -36,7 +36,7 @@ type BiFunction
 @Parameterized(["T"])
 type BinaryOperator
     is java.util.function.BinaryOperator
-    for BiFunction, Object
+    for BiFunction
 {
     fun apply(ta: Object, tb: Object): Object;
 }
@@ -374,7 +374,7 @@ type ToLongFunction
 @Parameterized(["T"])
 type UnaryOperator
     is java.util.function.UnaryOperator
-    for Function, Object
+    for Function
 {
     fun apply(t: Object): Object;
 }

--- a/spec/java/util/function/_interfaces.lsl
+++ b/spec/java/util/function/_interfaces.lsl
@@ -38,7 +38,7 @@ type BinaryOperator
     is java.util.function.BinaryOperator
     for BiFunction
 {
-    fun apply(ta: Object, tb: Object): Object;
+    // fun apply(ta: Object, tb: Object): Object;
 }
 
 
@@ -376,5 +376,5 @@ type UnaryOperator
     is java.util.function.UnaryOperator
     for Function
 {
-    fun apply(t: Object): Object;
+    // fun apply(t: Object): Object;
 }

--- a/spec/java/util/regex/Pattern_n_Matcher.lsl
+++ b/spec/java/util/regex/Pattern_n_Matcher.lsl
@@ -4,7 +4,7 @@ libsl "1.1.0";
 library std
     version "11"
     language "Java"
-    url "-";
+    url "https://github.com/openjdk/jdk11/tree/master/src/java.base/share/classes/java/util/regex";
 
 // imports
 

--- a/spec/java/util/stream/_interfaces.lsl
+++ b/spec/java/util/stream/_interfaces.lsl
@@ -1,29 +1,42 @@
 //#! pragma: non-synthesizable
 libsl "1.1.0";
 
-library `std:collections`
+library std
     version "11"
     language "Java"
-    url "-";
+    url "https://github.com/openjdk/jdk11/tree/master/src/java.base/share/classes/java/util/stream";
+
+// imports
 
 import java.common;
 
 
-type DoubleStream is java.util.stream.DoubleStream for Object {
-    // ???
-}
+// semantic types
 
-type IntStream is java.util.stream.IntStream for Object {
-    // ???
-}
-
-type LongStream is java.util.stream.LongStream for Object {
-    // ???
-}
-
-
-// #problem: type parameter
 @Parameterized(["T"])
-type Stream is java.util.stream.Stream for Object {
-    // ???
+type Stream
+    is java.util.stream.Stream
+    for Object
+{
+}
+
+
+type DoubleStream
+    is java.util.stream.DoubleStream
+    for Stream
+{
+}
+
+
+type IntStream
+    is java.util.stream.IntStream
+    for Stream
+{
+}
+
+
+type LongStream
+    is java.util.stream.LongStream
+    for Stream
+{
 }

--- a/spec/translator.actions.lsl
+++ b/spec/translator.actions.lsl
@@ -10,7 +10,7 @@ library any
 import translator.annotations;
 import actions.array;
 import actions.list;
-//import actions.map; // #problem: types with multiple type parameters
+import actions.map;
 
 
 /// generator-specific actions

--- a/spec/translator.actions.lsl
+++ b/spec/translator.actions.lsl
@@ -77,3 +77,6 @@ define action NOT_IMPLEMENTED (
 
 @StopsControlFlow
 define action TODO (): void;
+
+// do nothing explicitly but detectable by the translator if needed
+define action DO_NOTHING (): void;

--- a/spec/translator.actions.lsl
+++ b/spec/translator.actions.lsl
@@ -4,7 +4,7 @@ libsl "1.1.0";
 // TODO: remove debug code
 library any
     version "*"
-    language "any"
+    language "*"
     url "-";
 
 import translator.annotations;
@@ -16,16 +16,21 @@ import actions.list;
 /// generator-specific actions
 
 
-define action ASSUME (predicate: bool): void;
+define action ASSUME (
+        predicate: bool
+    ): void;
 
-define action SYMBOLIC(
+
+define action SYMBOLIC (
         valueType: string // literal!
     ): any;
+
 
 define action SYMBOLIC_ARRAY (
         elementType: string, // literal!
         size: int32
     ): array<any>;
+
 
 define action DEBUG_DO (
         code: string // literal!
@@ -34,37 +39,41 @@ define action DEBUG_DO (
 
 // note: result variable may be shared
 // usage example: action LOOP_FOR(i, 0, 10, +1, loop_body_proc(i, list, x, y));
-define action LOOP_FOR(
-    iterator: int32,   // direct variable reference!
-    lowerBound: int32,
-    upperBound: int32,
-    step: int32,
-    bodyProc: any      // direct call to a subroutine!
-): void;
+define action LOOP_FOR (
+        iterator: int32,   // variable!
+        lowerBound: int32,
+        upperBound: int32,
+        step: int32,
+        bodyProc: any      // subroutine call!
+    ): void;
 
 
 // note: result variable may be shared
 // usage example: action LOOP_WHILE(a < b, loop_body_proc(a));
-define action LOOP_WHILE(
-    predicate: bool,
-    bodyProc: any    // direct call to a subroutine!
-): void;
-
-define action LOOP_BREAK();
+define action LOOP_WHILE (
+        predicate: bool,
+        bodyProc: any    // subroutine call!
+    ): void;
 
 
-// disables code generation for subroutine and uses its body as an element for loop or other structure
-// should be used only on subroutines
-annotation LambdaComponent();
+define action LOOP_BREAK (): void;
 
 
-// specification development -related aspects
+
+/// specification development -related aspects
+
 
 @StopsControlFlow
-define action ERROR(message: string): void;
+define action ERROR (
+        message: string
+    ): void;
+
 
 @StopsControlFlow
-define action NOT_IMPLEMENTED(reason: string): void;
+define action NOT_IMPLEMENTED (
+        reason: string
+    ): void;
+
 
 @StopsControlFlow
-define action TODO(): void;
+define action TODO (): void;

--- a/spec/translator.annotations.lsl
+++ b/spec/translator.annotations.lsl
@@ -4,7 +4,7 @@ libsl "1.1.0";
 // TODO: remove debug code
 library any
     version "*"
-    language "Java"
+    language "*"
     url "-";
 
 
@@ -22,40 +22,34 @@ annotation AnnotatedWith (
 annotation AutoInline;
 
 
-// Stores the result of a function computation as a private field inside of the generated class.
-// Something like: `private Set __cached_keySet = null;`
-annotation CacheOnce;
-
-
-// Stores the result of a function computation as a private static field inside of the generated class.
-// Something like: `private static Set __cached_keySet = null;`
-annotation CacheStaticOnce;
-
-
 // The marked feature is no longer needed or required.
 annotation Deprecated (
-    hint: string = "",
+    note: string = "",
     forRemoval: bool = false,
 );
 
 
-// Specifies expected parent automaton and a class-container.
-annotation From (
-    parentAutomatonName: string,
-);
+// The declared type have no direct connection any of the existing JSL classes,
+// thus requiring the creation of a completely new one.
+annotation GenerateMe;
+
+
+// disables code generation for subroutine and uses its body as an element for loop or other structure
+// should be used only on subroutines
+annotation LambdaComponent;
 
 
 // The merked method does not return to normal execution.
 annotation NoReturn;
 
 
-// #problem
+// unused
 annotation Parameterized (
     typeParameters: array<string>,
 );
 
 
-// #problem
+// unused
 annotation ParameterizedResult (
     typeParameters: array<string>,
 );
@@ -65,10 +59,11 @@ annotation ParameterizedResult (
 annotation StopsControlFlow;
 
 
+// unused
 // Associates the type on the LEFT side of typealias with the specified type.
 //@Deprecated
 annotation TypeMapping (
     fullClassName: string = null,
     builtin: bool = false,
-    typeVariable: bool = false, // #problem
+    typeVariable: bool = false, // unused
 );

--- a/spec/translator.annotations.lsl
+++ b/spec/translator.annotations.lsl
@@ -34,9 +34,8 @@ annotation Deprecated (
 annotation GenerateMe ();
 
 
-// disables code generation for subroutine and uses its body as an element for loop or other structure
-// should be used only on subroutines
-annotation Phantom ();
+// Indicates that a subroutine should be callable by other automata types and instances.
+annotation KeepVisible ();
 
 
 // The merked method does not return to normal execution.
@@ -48,11 +47,15 @@ annotation Parameterized (
     typeParameters: array<string>,
 );
 
-
 // unused
 annotation ParameterizedResult (
     typeParameters: array<string>,
 );
+
+
+// disables code generation for subroutine and uses its body as an element for loop or other structure
+// should be used only on subroutines
+annotation Phantom ();
 
 
 // The marked action stops execution of current control flow by throwing exception or other means.

--- a/spec/translator.annotations.lsl
+++ b/spec/translator.annotations.lsl
@@ -19,7 +19,7 @@ annotation AnnotatedWith (
 
 
 // Forces the body of a specified subroutine to be copy-pasted at the callsite.
-annotation AutoInline;
+annotation AutoInline ();
 
 
 // The marked feature is no longer needed or required.
@@ -31,16 +31,16 @@ annotation Deprecated (
 
 // The declared type have no direct connection any of the existing JSL classes,
 // thus requiring the creation of a completely new one.
-annotation GenerateMe;
+annotation GenerateMe ();
 
 
 // disables code generation for subroutine and uses its body as an element for loop or other structure
 // should be used only on subroutines
-annotation Phantom;
+annotation Phantom ();
 
 
 // The merked method does not return to normal execution.
-annotation NoReturn;
+annotation NoReturn ();
 
 
 // unused
@@ -56,7 +56,7 @@ annotation ParameterizedResult (
 
 
 // The marked action stops execution of current control flow by throwing exception or other means.
-annotation StopsControlFlow;
+annotation StopsControlFlow ();
 
 
 // unused

--- a/spec/translator.annotations.lsl
+++ b/spec/translator.annotations.lsl
@@ -36,7 +36,7 @@ annotation GenerateMe;
 
 // disables code generation for subroutine and uses its body as an element for loop or other structure
 // should be used only on subroutines
-annotation LambdaComponent;
+annotation Phantom;
 
 
 // The merked method does not return to normal execution.


### PR DESCRIPTION
Key changes:
- Added necessary methods to interface declarations.
- Fixed invalid types for some action declarations.
- Added `@FunctionalInterface` annotation
- Added declaration for `CALL_METHOD` action.
- Added a `DO_NOTHING` action to explicitly state that this is the intended thing to do.
- Added links to JDK repository in modified files.
- Renamed `@LambdaComponent` to `@Phantom`.
- Removed declarations for caching-related activities (`@CacheOnce` and `@CahceStaticOnce`).
- Removed annotation `@From` (unused).
- Minor formatting changes.