### PR TITLE
Removed `ARRAY_GET` and `ARRAY_SET` actions

### DIFF
--- a/spec/actions.array.lsl
+++ b/spec/actions.array.lsl
@@ -24,11 +24,6 @@ define action ARRAY_FREE (
 // === READ operations ===
 
 
-define action ARRAY_GET (
-        arr: array<any>,
-        itemIndex: int32
-    ): any;
-
 define action ARRAY_SIZE (
         arr: array<any>
     ): int32;
@@ -49,12 +44,6 @@ define action ARRAY_COPY (
         dst: array<any>,
         dstPos: int32,
         count: int32
-    ): void;
-
-define action ARRAY_SET (
-        arr: array<any>,
-        itemIndex: int32,
-        value: any
     ): void;
 
 

--- a/spec/java/lang/_interfaces.lsl
+++ b/spec/java/lang/_interfaces.lsl
@@ -33,8 +33,6 @@ type CharSequence
     fun length(): int;
 
     fun charAt(index: int): char;
-
-    fun toString(): string; // #problem: using forward-declared type
 }
 
 type Character is java.lang.Character for Object, char {}

--- a/spec/java/lang/_interfaces.lsl
+++ b/spec/java/lang/_interfaces.lsl
@@ -24,6 +24,8 @@ type Float  is java.lang.Float  for Object, float32 {}
 type Double is java.lang.Double for Object, float64 {}
 
 
+// string-related operations
+
 type CharSequence
     is java.lang.CharSequence
     for Object
@@ -36,11 +38,16 @@ type CharSequence
 }
 
 type Character is java.lang.Character for Object, char {}
-type String    is java.lang.String    for CharSequence, string {}
+
+type String
+    is java.lang.String
+    for CharSequence, string
+{
+    fun compareTo(anotherString: string): int; // #problem: self-reference
+}
 
 
 // general interfaces
-
 
 type Runnable
     is java.lang.Runnable
@@ -57,16 +64,26 @@ type Throwable
 }
 
 
+@Parameterized(["E"])
+type Iterator
+    is java.util.Iterator
+    for Object
+{
+    fun hasNext(): boolean;
+
+    fun next(): Object;
+
+    fun remove(): void;
+}
+
+
 @Parameterized(["T"])
 type Iterable
     is java.lang.Iterable
     for Object
 {
+    fun iterator(): Iterator;
+
+    // #problem: cannot use Spliterator and Consumer here
+    // fun spliterator(): Spliterator;
 }
-
-
-
-// !!! temporary definitions
-
-type StringBuffer is java.lang.StringBuffer for Object {}
-type StringBuilder is java.lang.StringBuilder for Object {}

--- a/spec/java/util/_interfaces.lsl
+++ b/spec/java/util/_interfaces.lsl
@@ -23,15 +23,7 @@ type Comparator
 }
 
 
-@Parameterized(["E"])
-type Iterator
-    is java.util.Iterator
-    for Object
-{
-    fun hasNext(): boolean;
-
-    fun next(): Object;
-}
+// Iterator is declared in 'java/lang/_interfaces.lsl'
 
 
 @Parameterized(["T"])
@@ -39,7 +31,23 @@ type Spliterator
     is java.util.Spliterator
     for Object
 {
+    fun tryAdvance(@Parameterized(["? super T"]) _action: Consumer): boolean;
+
+    fun forEachRemaining(@Parameterized(["? super T"]) _action: Consumer): void;
+
+    fun getExactSizeIfKnown(): long;
+
+    fun characteristics(): int;
 }
+
+val SPLITERATOR_DISTINCT:   int = 1;
+val SPLITERATOR_SORTED:     int = 4;
+val SPLITERATOR_ORDERED:    int = 16;
+val SPLITERATOR_SIZED:      int = 64;
+val SPLITERATOR_NONNULL:    int = 256;
+val SPLITERATOR_IMMUTABLE:  int = 1024;
+val SPLITERATOR_CONCURRENT: int = 4096;
+val SPLITERATOR_SUBSIZED:   int = 16384;
 
 
 @Parameterized(["K", "V"])
@@ -124,6 +132,8 @@ type Collection
     //fun retainAll(@Parameterized(["?"]) c: Collection): boolean;
 
     fun clear(): void;
+
+    // #problem: cannot use Stream here
 }
 
 
@@ -164,4 +174,15 @@ type ListIterator
     is java.util.ListIterator
     for Iterator
 {
+    fun add(e: Object): void;
+
+    fun hasPrevious(): boolean;
+
+    fun nextIndex(): int;
+
+    fun previous(): Object;
+
+    fun previousIndex(): int;
+
+    fun set(e: Object): void;
 }

--- a/spec/java/util/function/_interfaces.lsl
+++ b/spec/java/util/function/_interfaces.lsl
@@ -20,7 +20,7 @@ type BiConsumer
 {
     fun accept(t: Object, u: Object): void;
 
-    // #problem: there are other methods but it will break `is-functional-interface` detection mechanism
+    // #question: do we need combinational methods?
 }
 
 

--- a/spec/java/util/stream/_interfaces.lsl
+++ b/spec/java/util/stream/_interfaces.lsl
@@ -10,10 +10,12 @@ library std
 
 import java.common;
 import java/lang/_interfaces;
+import java/util/function/_interfaces;
 
 
 // semantic types
 
+@Parameterized(["T", "S"])
 type BaseStream
     is java.util.stream.BaseStream
     for Object
@@ -27,6 +29,25 @@ type BaseStream
     fun isParallel(): boolean;
 
     fun close(): void;
+}
+
+
+@Parameterized(["T", "A", "R"])
+type Collector
+    is java.util.stream.Collector
+    for Object
+{
+    @ParameterizedResult(["A"])
+    fun supplier(): Supplier;
+
+    @ParameterizedResult(["A", "T"])
+    fun accumulator(): BiConsumer;
+
+    @ParameterizedResult(["A"])
+    fun combiner(): BinaryOperator;
+
+    @ParameterizedResult(["A", "R"])
+    fun finisher(): Function;
 }
 
 

--- a/spec/java/util/stream/_interfaces.lsl
+++ b/spec/java/util/stream/_interfaces.lsl
@@ -9,15 +9,38 @@ library std
 // imports
 
 import java.common;
+import java/lang/_interfaces;
 
 
 // semantic types
 
+type BaseStream
+    is java.util.stream.BaseStream
+    for Object
+{
+    @ParameterizedResult(["T"])
+    fun iterator(): Iterator;
+
+    @ParameterizedResult(["T"])
+    fun spliterator(): Spliterator;
+
+    fun isParallel(): boolean;
+
+    fun close(): void;
+}
+
+
+
 @Parameterized(["T"])
 type Stream
     is java.util.stream.Stream
-    for Object
+    for BaseStream
 {
+    fun forEach(@Parameterized(["? super T"]) _action: Consumer): void;
+
+    fun forEachOrdered(@Parameterized(["? super T"]) _action: Consumer): void;
+
+    fun toArray(): array<Object>;
 }
 
 


### PR DESCRIPTION
Key changes:
- Removed `ARRAY_GET/SET` action declarations (deprecated).
- Minor improvements to interface declarations.