### PR TITLE
Fixes to type declarations and Missing actions

### DIFF
--- a/spec/java.common.lsl
+++ b/spec/java.common.lsl
@@ -37,8 +37,7 @@ annotation implements (
 );
 
 annotation throws (
-    exceptionTypes: array<string> = [],
-    generic: bool = false,
+    exceptionTypes: array<string>,
 );
 
 annotation synchronized ();
@@ -77,12 +76,12 @@ type Object is java.lang.Object for Object
 
 // language-specific features
 
-
 @StopsControlFlow
 define action THROW_NEW (
         exceptionType: string,
         params: array<any>
     ): void;
+
 
 @StopsControlFlow
 define action THROW_VALUE (
@@ -90,10 +89,28 @@ define action THROW_VALUE (
     ): void;
 
 
+/*
+Usage example:
+action TRY_CATCH(
+    _try_proc(),
+    [
+        ["java.lang.Error",     _catch_proc_a()],
+        ["java.util.Exception", _catch_proc_b()],
+    ]
+);
+*/
+define action TRY_CATCH (
+        tryBlock: void,               // subroutine call!
+        catchTable: array<array<any>> // pairs of {name: str, handler: call}
+    ): void;
+
+// Use to get reference to the caught exception within the 'catch' section of 'try-catch' block.
+// WARNING: applicable only within the exception handler ("catch") subroutine
+define action CATCH_GET_EXCEPTION_REF (
+    ): Object;
 
 
 // work-arounds
-
 
 define action CALL (
         callable: any,
@@ -108,41 +125,25 @@ define action CALL_METHOD (
     ): any;
 
 
-/*
-Usage example:
-action TRY_CATCH(
-    _try_proc(),
-    [
-        ["java.lang.Error",     _catch_proc_a()],
-        ["java.util.Exception", _catch_proc_b()],
-    ]
-);
-*/
-define action TRY_CATCH (
-        tryBlock: any,                // subroutine call!
-        catchTable: array<array<any>> // pairs of {name: str, handler: call}
-    ): void;
+// helper methods built into the language runtime
+
+define action OBJECT_EQUALS (
+        a: any,
+        b: any
+    ): boolean;
 
 
-// Used to get reference to the caught exception within the 'catch' section of 'try-catch' block.
-// WARNING: applicable only within the exception handler ("catch") subroutine
-define action CATCH_GET_EXCEPTION_REF (
-    ): Object;
+define action OBJECT_HASH_CODE (
+        value: any
+    ): int;
 
 
-
-// helper methods in runtime
+define action OBJECT_TO_STRING (
+        value: any
+    ): string;
 
 
 define action OBJECT_SAME_TYPE (
         a: any,
         b: any
     ): boolean;
-
-define action OBJECT_TO_STRING (
-        value: any
-    ): string;
-
-define action OBJECT_HASH_CODE (
-        value: any
-    ): int;

--- a/spec/java/util/stream/_interfaces.lsl
+++ b/spec/java/util/stream/_interfaces.lsl
@@ -10,6 +10,7 @@ library std
 
 import java.common;
 import java/lang/_interfaces;
+import java/util/_interfaces;
 import java/util/function/_interfaces;
 
 

--- a/spec/translator.actions.lsl
+++ b/spec/translator.actions.lsl
@@ -37,22 +37,22 @@ define action DEBUG_DO (
     ): any;
 
 
-// note: result variable may be shared
+// note: result variable should be passed EXPLICITLY!
 // usage example: action LOOP_FOR(i, 0, 10, +1, loop_body_proc(i, list, x, y));
 define action LOOP_FOR (
         iterator: int32,   // variable!
         lowerBound: int32,
         upperBound: int32,
         step: int32,
-        bodyProc: any      // subroutine call!
+        bodyProc: void     // subroutine call!
     ): void;
 
 
-// note: result variable may be shared
+// note: result variable should be passed EXPLICITLY!
 // usage example: action LOOP_WHILE(a < b, loop_body_proc(a));
 define action LOOP_WHILE (
         predicate: bool,
-        bodyProc: any    // subroutine call!
+        bodyProc: void   // subroutine call!
     ): void;
 
 

--- a/spec/translator.annotations.lsl
+++ b/spec/translator.annotations.lsl
@@ -34,7 +34,7 @@ annotation Deprecated (
 annotation GenerateMe ();
 
 
-// Indicates that a subroutine should be callable by other automata types and instances.
+// Indicates that a subroutine should be accessible to other automata.
 annotation KeepVisible ();
 
 
@@ -42,12 +42,12 @@ annotation KeepVisible ();
 annotation NoReturn ();
 
 
-// unused
+// <unused>
 annotation Parameterized (
     typeParameters: array<string>,
 );
 
-// unused
+// <unused>
 annotation ParameterizedResult (
     typeParameters: array<string>,
 );
@@ -62,7 +62,7 @@ annotation Phantom ();
 annotation StopsControlFlow ();
 
 
-// unused
+// <unused>
 // Associates the type on the LEFT side of typealias with the specified type.
 //@Deprecated
 annotation TypeMapping (


### PR DESCRIPTION
Key changes:
- Fixed type resolution for `Spliterator` in `java/util/stream/_interfaces.lsl`.
- Added missing declaration for `OBJECT_EQUALS` action.
- Removed optional `generic` parameter from `@throws` annotation (unused).
- Minor action signature changes to better indicate a call to a subroutine(s) that have no return value (no `result` variable).