### PR TITLE
Fixes for `java.util.HashSet` and `java.util.LinkedHashSet`

### DIFF
--- a/spec/java/util/HashSet.KeyIterator.lsl
+++ b/spec/java/util/HashSet.KeyIterator.lsl
@@ -89,7 +89,8 @@ automaton HashSet_KeyIteratorAutomaton
         if (!atValidPosition)
             action THROW_NEW("java.util.NoSuchElementException", []);
 
-        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(this.unseenKeys);
+        action MAP_REMOVE(this.unseenKeys, key);
         action ASSUME(key != this.currentKey);
 
         this.currentKey = key;
@@ -144,7 +145,8 @@ automaton HashSet_KeyIteratorAutomaton
     {
         _checkForComodification();
 
-        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(this.unseenKeys);
+        action MAP_REMOVE(this.unseenKeys, key);
         action ASSUME(key != this.currentKey);
 
         this.currentKey = key;

--- a/spec/java/util/HashSet.KeyIterator.lsl
+++ b/spec/java/util/HashSet.KeyIterator.lsl
@@ -89,12 +89,9 @@ automaton HashSet_KeyIteratorAutomaton
         if (!atValidPosition)
             action THROW_NEW("java.util.NoSuchElementException", []);
 
-        val key: Object = action SYMBOLIC("java.lang.Object");
-        action ASSUME(key != null);
-        action ASSUME(key != this.currentKey);
         val parentStorage: map<Object, Object> = HashSetAutomaton(this.parent).storage;
-        val sourceStorageHasKey: boolean = action MAP_HAS_KEY(parentStorage, key);
-        action ASSUME(sourceStorageHasKey);
+        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        action ASSUME(key != this.currentKey);
         val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
         action ASSUME(!dstStorageHasKey);
 
@@ -151,14 +148,11 @@ automaton HashSet_KeyIteratorAutomaton
     {
         _checkForComodification();
 
-        val key: Object = action SYMBOLIC("java.lang.Object");
-        action ASSUME(key != null);
-        action ASSUME(key != this.currentKey);
         val parentStorage: map<Object, Object> = HashSetAutomaton(this.parent).storage;
-        val sourceStorageHasKey: boolean = action MAP_HAS_KEY(parentStorage, key);
-        action ASSUME(sourceStorageHasKey);
-        val destStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
-        action ASSUME(!destStorageHasKey);
+        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        action ASSUME(key != this.currentKey);
+        val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
+        action ASSUME(!dstStorageHasKey);
 
         this.currentKey = key;
         action MAP_SET(this.visitedKeys, this.currentKey, SOMETHING);

--- a/spec/java/util/HashSet.KeyIterator.lsl
+++ b/spec/java/util/HashSet.KeyIterator.lsl
@@ -19,7 +19,7 @@ import java/util/function/Consumer;
 automaton HashSet_KeyIteratorAutomaton
 (
     var expectedModCount: int,
-    var visitedKeys: map<Object, Object>,
+    var unseenKeys: map<Object, Object>,
     var parent: HashSet
 )
 : HashSet_KeyIterator
@@ -89,16 +89,12 @@ automaton HashSet_KeyIteratorAutomaton
         if (!atValidPosition)
             action THROW_NEW("java.util.NoSuchElementException", []);
 
-        val parentStorage: map<Object, Object> = HashSetAutomaton(this.parent).storage;
-        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
         action ASSUME(key != this.currentKey);
-        val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
-        action ASSUME(!dstStorageHasKey);
 
         this.currentKey = key;
         result = key;
 
-        action MAP_SET(this.visitedKeys, this.currentKey, SOMETHING);
         this.index += 1;
         this.nextWasCalled = true;
     }
@@ -148,14 +144,10 @@ automaton HashSet_KeyIteratorAutomaton
     {
         _checkForComodification();
 
-        val parentStorage: map<Object, Object> = HashSetAutomaton(this.parent).storage;
-        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
         action ASSUME(key != this.currentKey);
-        val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
-        action ASSUME(!dstStorageHasKey);
 
         this.currentKey = key;
-        action MAP_SET(this.visitedKeys, this.currentKey, SOMETHING);
 
         action CALL(userAction, [key]);
         i += 1;

--- a/spec/java/util/HashSet.main.lsl
+++ b/spec/java/util/HashSet.main.lsl
@@ -127,10 +127,7 @@ automaton HashSetAutomaton
 
     proc _generateKey (visitedKeys: map<Object, Object>): Object
     {
-        result = action SYMBOLIC("java.lang.Object");
-        action ASSUME(result != null);
-        val isKeyExist: boolean = action MAP_HAS_KEY(this.storage, result);
-        action ASSUME(isKeyExist);
+        result = action MAP_GET_ANY_KEY(this.storage);
 
         val isKeyWasVisited: boolean = action MAP_HAS_KEY(visitedKeys, result);
         action ASSUME(!isKeyWasVisited);

--- a/spec/java/util/HashSet.main.lsl
+++ b/spec/java/util/HashSet.main.lsl
@@ -58,6 +58,7 @@ automaton HashSetAutomaton
         toArray(HashSet),
         toArray(HashSet, array<Object>),
         toArray(HashSet, IntFunction),
+        toString,
 
         // write operations
         add,
@@ -662,5 +663,12 @@ automaton HashSetAutomaton
     @private fun *.readObject (@target self: HashSet, s: ObjectInputStream): void
     {
         action NOT_IMPLEMENTED("no serialization support yet");
+    }
+
+
+    // within java.util.AbstractCollection
+    fun *.toString (@target self: HashSet): String
+    {
+        result = action OBJECT_TO_STRING(this.storage);
     }
 }

--- a/spec/java/util/HashSet.main.lsl
+++ b/spec/java/util/HashSet.main.lsl
@@ -126,13 +126,6 @@ automaton HashSetAutomaton
     }
 
 
-    @KeepVisible proc _generateKey (unseenKeys: map<Object, Object>): Object
-    {
-        result = action MAP_GET_ANY_KEY(unseenKeys);
-        action MAP_REMOVE(unseenKeys, result);
-    }
-
-
     // constructors
 
     constructor *.HashSet (@target self: HashSet)
@@ -218,9 +211,7 @@ automaton HashSetAutomaton
 
     fun *.clone (@target self: HashSet): Object
     {
-        val storageCopy: map<Object, Object> = action MAP_NEW();
-
-        action MAP_UNITE_WITH(storageCopy, this.storage);
+        val storageCopy: map<Object, Object> = action MAP_CLONE(this.storage);
 
         result = new HashSetAutomaton(state = Initialized,
             storage = storageCopy,
@@ -246,8 +237,7 @@ automaton HashSetAutomaton
 
     fun *.iterator (@target self: HashSet): Iterator
     {
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         result = new HashSet_KeyIteratorAutomaton(state = Initialized,
             expectedModCount = this.modCount,
             unseenKeys = unseenKeys,
@@ -282,8 +272,7 @@ automaton HashSetAutomaton
     fun *.spliterator (@target self: HashSet): Spliterator
     {
         val keysStorageArray: array<Object> = action ARRAY_NEW("java.lang.Object", this.length);
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
         var i: int = 0;
         action LOOP_FOR(
@@ -305,7 +294,8 @@ automaton HashSetAutomaton
 
     @Phantom proc fromMapToArray_loop (i: int, keysStorageArray: array<Object>, unseenKeys: map<Object, Object>): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         keysStorageArray[i] = key;
     }
@@ -370,8 +360,7 @@ automaton HashSetAutomaton
         }
         else
         {
-            val unseenKeys: map<Object, Object> = action MAP_NEW();
-            action MAP_UNITE_WITH(unseenKeys, this.storage);
+            val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
             action LOOP_WHILE(
                 i < this.length,
@@ -401,7 +390,8 @@ automaton HashSetAutomaton
 
     @Phantom proc _removeAllElements_loop_indirect (i: int, c: Collection, unseenKeys: map<Object, Object>): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         val isCollectionContainsKey: boolean = action CALL_METHOD(c, "contains", [key]);
 
@@ -420,8 +410,7 @@ automaton HashSetAutomaton
         val len: int = this.length;
         result = action ARRAY_NEW("java.lang.Object", len);
         val expectedModCount: int = this.modCount;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         var i: int = 0;
 
         action LOOP_FOR(
@@ -435,7 +424,8 @@ automaton HashSetAutomaton
 
     @Phantom proc toArray_loop(i: int, unseenKeys: map<Object, Object>, result: array<Object>): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         result[i] = key;
     }
@@ -446,8 +436,7 @@ automaton HashSetAutomaton
         val expectedModCount: int = this.modCount;
         val aLen: int = action ARRAY_SIZE(a);
         val len: int = this.length;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         var i: int = 0;
 
         if (aLen < len)
@@ -475,8 +464,7 @@ automaton HashSetAutomaton
         val len: int = this.length;
         result = action CALL(generator, [0]) as array<Object>;
         val expectedModCount: int = this.modCount;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         var i: int = 0;
 
         action LOOP_FOR(
@@ -568,8 +556,7 @@ automaton HashSetAutomaton
         val lengthBeforeAdd: int = this.length;
         val expectedModCount: int = this.modCount;
         var i: int = 0;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
         action LOOP_WHILE(
             i < lengthBeforeAdd,
@@ -591,7 +578,8 @@ automaton HashSetAutomaton
 
     @Phantom proc _removeIf_loop (i: int, unseenKeys: map<Object, Object>, filter: Predicate): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         var isDelete: boolean = action CALL(filter, [key]);
 
@@ -612,8 +600,7 @@ automaton HashSetAutomaton
 
         var i: int = 0;
         val expectedModCount: int = this.modCount;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
         action LOOP_WHILE(
             i < this.length,
@@ -626,7 +613,8 @@ automaton HashSetAutomaton
 
     @Phantom proc forEach_loop (i: int, unseenKeys: map<Object, Object>, userAction: Consumer): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         action CALL(userAction, [key]);
 

--- a/spec/java/util/LinkedHashSet.KeyIterator.lsl
+++ b/spec/java/util/LinkedHashSet.KeyIterator.lsl
@@ -88,12 +88,9 @@ automaton LinkedHashSet_KeyIteratorAutomaton
         if (!atValidPosition)
             action THROW_NEW("java.util.NoSuchElementException", []);
 
-        val key: Object = action SYMBOLIC("java.lang.Object");
-        action ASSUME(key != null);
-        action ASSUME(key != this.currentKey);
         val parentStorage: map<Object, Object> = LinkedHashSetAutomaton(this.parent).storage;
-        val sourceStorageHasKey: boolean = action MAP_HAS_KEY(parentStorage, key);
-        action ASSUME(sourceStorageHasKey);
+        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        action ASSUME(key != this.currentKey);
         val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
         action ASSUME(!dstStorageHasKey);
 
@@ -150,14 +147,11 @@ automaton LinkedHashSet_KeyIteratorAutomaton
     {
         _checkForComodification();
 
-        val key: Object = action SYMBOLIC("java.lang.Object");
-        action ASSUME(key != null);
-        action ASSUME(key != this.currentKey);
         val parentStorage: map<Object, Object> = LinkedHashSetAutomaton(this.parent).storage;
-        val sourceStorageHasKey: boolean = action MAP_HAS_KEY(parentStorage, key);
-        action ASSUME(sourceStorageHasKey);
-        val destStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
-        action ASSUME(!destStorageHasKey);
+        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        action ASSUME(key != this.currentKey);
+        val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
+        action ASSUME(!dstStorageHasKey);
 
         this.currentKey = key;
         action MAP_SET(this.visitedKeys, this.currentKey, SOMETHING);

--- a/spec/java/util/LinkedHashSet.KeyIterator.lsl
+++ b/spec/java/util/LinkedHashSet.KeyIterator.lsl
@@ -88,7 +88,8 @@ automaton LinkedHashSet_KeyIteratorAutomaton
         if (!atValidPosition)
             action THROW_NEW("java.util.NoSuchElementException", []);
 
-        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(this.unseenKeys);
+        action MAP_REMOVE(this.unseenKeys, key);
         action ASSUME(key != this.currentKey);
 
         this.currentKey = key;
@@ -143,7 +144,8 @@ automaton LinkedHashSet_KeyIteratorAutomaton
     {
         _checkForComodification();
 
-        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(this.unseenKeys);
+        action MAP_REMOVE(this.unseenKeys, key);
         action ASSUME(key != this.currentKey);
 
         this.currentKey = key;

--- a/spec/java/util/LinkedHashSet.KeyIterator.lsl
+++ b/spec/java/util/LinkedHashSet.KeyIterator.lsl
@@ -19,7 +19,7 @@ import java/util/function/Consumer;
 automaton LinkedHashSet_KeyIteratorAutomaton
 (
     var expectedModCount: int,
-    var visitedKeys: map<Object, Object>,
+    var unseenKeys: map<Object, Object>,
     var parent: LinkedHashSet
 )
 : LinkedHashSet_KeyIterator
@@ -88,16 +88,12 @@ automaton LinkedHashSet_KeyIteratorAutomaton
         if (!atValidPosition)
             action THROW_NEW("java.util.NoSuchElementException", []);
 
-        val parentStorage: map<Object, Object> = LinkedHashSetAutomaton(this.parent).storage;
-        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
         action ASSUME(key != this.currentKey);
-        val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
-        action ASSUME(!dstStorageHasKey);
 
         this.currentKey = key;
         result = key;
 
-        action MAP_SET(this.visitedKeys, this.currentKey, SOMETHING);
         this.index += 1;
         this.nextWasCalled = true;
     }
@@ -147,14 +143,10 @@ automaton LinkedHashSet_KeyIteratorAutomaton
     {
         _checkForComodification();
 
-        val parentStorage: map<Object, Object> = LinkedHashSetAutomaton(this.parent).storage;
-        val key: Object = action MAP_GET_ANY_KEY(parentStorage);
+        val key: Object = HashSetAutomaton(this.parent)._generateKey(this.unseenKeys);
         action ASSUME(key != this.currentKey);
-        val dstStorageHasKey: boolean = action MAP_HAS_KEY(this.visitedKeys, key);
-        action ASSUME(!dstStorageHasKey);
 
         this.currentKey = key;
-        action MAP_SET(this.visitedKeys, this.currentKey, SOMETHING);
 
         action CALL(userAction, [key]);
         i += 1;

--- a/spec/java/util/LinkedHashSet.main.lsl
+++ b/spec/java/util/LinkedHashSet.main.lsl
@@ -56,6 +56,7 @@ automaton LinkedHashSetAutomaton
         toArray(LinkedHashSet),
         toArray(LinkedHashSet, array<Object>),
         toArray(LinkedHashSet, IntFunction),
+        toString,
 
         // write operations
         add,
@@ -654,4 +655,10 @@ automaton LinkedHashSetAutomaton
         action NOT_IMPLEMENTED("no serialization support yet");
     }
 
+
+    // within java.util.AbstractCollection
+    fun *.toString (@target self: LinkedHashSet): String
+    {
+        result = action OBJECT_TO_STRING(this.storage);
+    }
 }

--- a/spec/java/util/LinkedHashSet.main.lsl
+++ b/spec/java/util/LinkedHashSet.main.lsl
@@ -124,10 +124,7 @@ automaton LinkedHashSetAutomaton
 
     proc _generateKey (visitedKeys: map<Object, Object>): Object
     {
-        result = action SYMBOLIC("java.lang.Object");
-        action ASSUME(result != null);
-        val isKeyExist: boolean = action MAP_HAS_KEY(this.storage, result);
-        action ASSUME(isKeyExist);
+        result = action MAP_GET_ANY_KEY(this.storage);
 
         val isKeyWasVisited: boolean = action MAP_HAS_KEY(visitedKeys, result);
         action ASSUME(!isKeyWasVisited);

--- a/spec/java/util/LinkedHashSet.main.lsl
+++ b/spec/java/util/LinkedHashSet.main.lsl
@@ -123,13 +123,6 @@ automaton LinkedHashSetAutomaton
     }
 
 
-    @KeepVisible proc _generateKey (unseenKeys: map<Object, Object>): Object
-    {
-        result = action MAP_GET_ANY_KEY(unseenKeys);
-        action MAP_REMOVE(unseenKeys, result);
-    }
-
-
     // constructors
 
     constructor *.LinkedHashSet (@target self: LinkedHashSet)
@@ -209,9 +202,7 @@ automaton LinkedHashSetAutomaton
 
     fun *.clone (@target self: LinkedHashSet): Object
     {
-        val storageCopy: map<Object, Object> = action MAP_NEW();
-
-        action MAP_UNITE_WITH(storageCopy, this.storage);
+        val storageCopy: map<Object, Object> = action MAP_CLONE(this.storage);
 
         result = new LinkedHashSetAutomaton(state = Initialized,
             storage = storageCopy,
@@ -237,8 +228,7 @@ automaton LinkedHashSetAutomaton
 
     fun *.iterator (@target self: LinkedHashSet): Iterator
     {
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         result = new LinkedHashSet_KeyIteratorAutomaton(state = Initialized,
             expectedModCount = this.modCount,
             unseenKeys = unseenKeys,
@@ -273,8 +263,7 @@ automaton LinkedHashSetAutomaton
     fun *.spliterator (@target self: LinkedHashSet): Spliterator
     {
         val keysStorageArray: array<Object> = action ARRAY_NEW("java.lang.Object", this.length);
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
         var i: int = 0;
         action LOOP_FOR(
@@ -295,7 +284,8 @@ automaton LinkedHashSetAutomaton
 
     @Phantom proc fromMapToArray_loop (i: int, keysStorageArray: array<Object>, unseenKeys: map<Object, Object>): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         keysStorageArray[i] = key;
     }
@@ -360,8 +350,7 @@ automaton LinkedHashSetAutomaton
         }
         else
         {
-            val unseenKeys: map<Object, Object> = action MAP_NEW();
-            action MAP_UNITE_WITH(unseenKeys, this.storage);
+            val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
             action LOOP_WHILE(
                 i < this.length,
                 _removeAllElements_loop_indirect(i, c, unseenKeys)
@@ -390,7 +379,8 @@ automaton LinkedHashSetAutomaton
 
     @Phantom proc _removeAllElements_loop_indirect (i: int, c: Collection, unseenKeys: map<Object, Object>): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         val isCollectionContainsKey: boolean = action CALL_METHOD(c, "contains", [key]);
 
@@ -409,8 +399,7 @@ automaton LinkedHashSetAutomaton
         val len: int = this.length;
         result = action ARRAY_NEW("java.lang.Object", len);
         val expectedModCount: int = this.modCount;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         var i: int = 0;
 
         action LOOP_FOR(
@@ -424,7 +413,8 @@ automaton LinkedHashSetAutomaton
 
     @Phantom proc toArray_loop(i: int, unseenKeys: map<Object, Object>, result: array<Object>): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         result[i] = key;
     }
@@ -435,8 +425,7 @@ automaton LinkedHashSetAutomaton
         val expectedModCount: int = this.modCount;
         val aLen: int = action ARRAY_SIZE(a);
         val len: int = this.length;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         var i: int = 0;
 
         if (aLen < len)
@@ -464,8 +453,7 @@ automaton LinkedHashSetAutomaton
         val len: int = this.length;
         result = action CALL(generator, [0]) as array<Object>;
         val expectedModCount: int = this.modCount;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
         var i: int = 0;
 
         action LOOP_FOR(
@@ -557,8 +545,7 @@ automaton LinkedHashSetAutomaton
         val lengthBeforeAdd: int = this.length;
         val expectedModCount: int = this.modCount;
         var i: int = 0;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
         action LOOP_WHILE(
             i < lengthBeforeAdd,
@@ -580,7 +567,8 @@ automaton LinkedHashSetAutomaton
 
     @Phantom proc _removeIf_loop (i: int, unseenKeys: map<Object, Object>, filter: Predicate): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         var isDelete: boolean = action CALL(filter, [key]);
 
@@ -601,8 +589,7 @@ automaton LinkedHashSetAutomaton
 
         var i: int = 0;
         val expectedModCount: int = this.modCount;
-        val unseenKeys: map<Object, Object> = action MAP_NEW();
-        action MAP_UNITE_WITH(unseenKeys, this.storage);
+        val unseenKeys: map<Object, Object> = action MAP_CLONE(this.storage);
 
         action LOOP_WHILE(
             i < this.length,
@@ -615,7 +602,8 @@ automaton LinkedHashSetAutomaton
 
     @Phantom proc forEach_loop (i: int, unseenKeys: map<Object, Object>, userAction: Consumer): void
     {
-        val key: Object = _generateKey(unseenKeys);
+        val key: Object = action MAP_GET_ANY_KEY(unseenKeys);
+        action MAP_REMOVE(unseenKeys, key);
 
         action CALL(userAction, [key]);
 


### PR DESCRIPTION
1. action SYMBOLIC was replaced by MAP_GET_ANY_KEY
2. Was added method toString();